### PR TITLE
Entferne Rahmen um Hyperlinks in PDF

### DIFF
--- a/sponsoring.tex
+++ b/sponsoring.tex
@@ -16,7 +16,7 @@
 \usepackage{chngpage} % Adjust page width
 \usepackage{calc} % Calculations
 \usepackage{color} % Colors
-\usepackage{hyperref} % Hyperlinks
+\usepackage[colorlinks=true, urlcolor=blue]{hyperref} % Hyperlinks
 \usepackage{subfig} % Subfigures (für fotos)
 \usepackage{float} % H placing specifier
 


### PR DESCRIPTION
Ich hasse die Rahmen um die Hyperlinks ;) Insbesondere Personen, welche LaTex nicht kennen, fragen sich möglicherweise auch, was diese komischen Rahmen sollen. Daher hier mein Vorschlag diese Rahmen zu entfernen und stattdessen die Links blau einzufärben.
